### PR TITLE
Fix some Python 2-isms in the vos code

### DIFF
--- a/vos/CadcCache.py
+++ b/vos/CadcCache.py
@@ -21,6 +21,7 @@ from SharedLock import SharedLock as SharedLock
 from CacheMetaData import CacheMetaData as CacheMetaData
 from logExceptions import logExceptions
 import utils
+from six import reraise
 
 libcPath = ctypes.util.find_library('c')
 libc = ctypes.cdll.LoadLibrary(libcPath)
@@ -245,9 +246,9 @@ class Cache(object):
                 # are propegated.
                 if not (isinstance(fileHandle.readException[1], EnvironmentError) and
                                 fileHandle.readException[1].errno == errno.ENOENT and not mustExist):
-                    raise fileHandle.readException[0], \
+                    reraise (fileHandle.readException[0], \
                         fileHandle.readException[1], \
-                        fileHandle.readException[2]
+                        fileHandle.readException[2])
                 # The file didn't exist on the backing store but its ok
                 fileHandle.fullyCached = True
                 fileHandle.gotHeader = True
@@ -926,8 +927,8 @@ class FileHandle(object):
 
             # Look for write failures.
             if self.flushException is not None:
-                raise self.flushException[0], self.flushException[1], \
-                    self.flushException[2]
+                reraise (self.flushException[0], self.flushException[1], \
+                    self.flushException[2])
 
             return 0
 

--- a/vos/fuse.py
+++ b/vos/fuse.py
@@ -405,7 +405,7 @@ class FUSE(object):
         """Decorator for the methods that follow"""
         try:
             return func(*args, **kwargs) or 0
-        except OSError, e:
+        except OSError as e:
             return -(e.errno or EFAULT)
         except Exception as e2:
             logging.error("%s %s" % (str(e2), traceback.format_exc()))
@@ -743,7 +743,7 @@ class Operations(object):
 
         if path != '/':
             raise FuseOSError(ENOENT)
-        return dict(st_mode=(S_IFDIR | 0755), st_nlink=2)
+        return dict(st_mode=(S_IFDIR | 0o755), st_nlink=2)
 
     def getxattr(self, path, name, position=0):
         raise FuseOSError(ENOTSUP)
@@ -847,7 +847,7 @@ class LoggingMixIn:
         try:
             ret = getattr(self, op)(path, *args)
             return ret
-        except OSError, e:
+        except OSError as e:
             ret = str(e)
             raise
         finally:

--- a/vos/vofs.py
+++ b/vos/vofs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2.7
 """A FUSE based filesystem view of VOSpace."""
+from __future__ import print_function
 import time
 import vos
 import sys
@@ -345,7 +346,7 @@ class VOFS(Operations):
 
         node = self.getNode(path)
         parent = self.getNode(os.path.dirname(path))
-        print node, parent
+        print (node, parent)
         # Force inheritance of group settings.
         node.groupread = parent.groupread
         node.groupwrite = parent.groupwrite
@@ -439,7 +440,7 @@ class VOFS(Operations):
         There is no distinction in VOSpace between hard and symbolic links.
         """
         try:
-            if target[0] != '/': target = '/' + target # MJG URL hack 
+            if target[0] != '/': target = '/' + target # MJG URL hack
             self.client.link(target, name)
         except OSError as os_error:
             raise FuseOSError(getattr(os_error, 'errno', EFAULT))


### PR DESCRIPTION
 that I noticed when running setup.py install. On running "python setup.py install" in Python 3 I noticed some compile errors in the "vos" subdirectory. These fixes should fix them in a python 2 or 3 compatible manner, which was the easiest way to fix them.