### PR TITLE
Fix import on machines that lack a fully qualified domain name

### DIFF
--- a/dl/queryClient.py
+++ b/dl/queryClient.py
@@ -128,7 +128,9 @@ DAL_SERVICE_URL = 'https://datalab.noao.edu' 	# The base DAL service URL
 
 # Allow the service URL for dev/test systems to override the default.
 THIS_HOST = socket.gethostname()			# host name
-THIS_IP	  = socket.gethostbyname(socket.gethostname())	# host IP address
+with socket.socket(type=socket.SOCK_DGRAM) as sock:
+    sock.connect(('192.0.2.1', 1))  # Example IP address, see RFC 5737
+    THIS_IP, _ = sock.getsockname()  # host IP address
 
 if THIS_HOST[:5] == 'dldev':
     DEF_SERVICE_ROOT = 'http://dldev.datalab.noao.edu'

--- a/dl/storeClient.py
+++ b/dl/storeClient.py
@@ -117,7 +117,9 @@ DEF_SERVICE_ROOT = 'https://datalab.noao.edu'
 
 # Allow the service URL for dev/test systems to override the default.
 THIS_HOST = socket.gethostname()                        # host name
-THIS_IP   = socket.gethostbyname(socket.gethostname())  # host IP address
+with socket.socket(type=socket.SOCK_DGRAM) as sock:
+    sock.connect(('192.0.2.1', 1))  # Example IP address, see RFC 5737
+    THIS_IP, _ = sock.getsockname()  # host IP address
 
 if THIS_HOST[:5] == 'dldev':
     DEF_SERVICE_ROOT = 'http://dldev.datalab.noao.edu'


### PR DESCRIPTION
Some machines do not have fully qualified domain names, and therefore `socket.gethostbyname(socket.gethostname())` fails, making it impossible to import `dl.queryClient`.

For example, on my NASA-managed MacBook, I get this error:

    >>> import socket
    >>> socket.gethostbyname(socket.gethostname())
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    socket.gaierror: [Errno 8] nodename nor servname provided, or not known

Instead, look up the host's IP address using the method suggested in https://stackoverflow.com/questions/166506#answer-28950776 of opening a datagram socket to a test IP address. We use one of the addresses from RFC 5737 "IPv4 Address Blocks Reserved for Documentation" so that we don't actually connect to a real IP address.